### PR TITLE
LL-32: Preprocess the dataset

### DIFF
--- a/csv_generator/csv_generator.py
+++ b/csv_generator/csv_generator.py
@@ -22,6 +22,7 @@ class CsvGenerator():
         return business_df, review_df
 
     def __clean_business_data(self, df: pd.DataFrame, columns: list[str]) -> pd.DataFrame:
+        df = df[df['isopen'] == 1]
         df = df[columns]
         df = df[df["categories"].str.contains("Cafe", na=False) | df['categories'].str.contains("Coffee", na=False)]
         self.business_ids = set(df['business_id'])
@@ -56,7 +57,7 @@ if __name__ == "__main__":
     hardcoded filenames, columns for now, need modification later
     """
     csv_generator = CsvGenerator("yelp_academic_dataset_business.csv", "yelp_academic_dataset_review.csv")
-    business_columns = ['is_open', 'postal_code', 'latitude',
+    business_columns = ['postal_code', 'latitude',
        'name', 'business_id', 'categories','address','city',
        'longitude','hours', 'stars','state','review_count']
     review_columns = ['business_id', 'text', 'stars', 'review_id', 'date']

--- a/csv_generator/csv_generator.py
+++ b/csv_generator/csv_generator.py
@@ -1,0 +1,63 @@
+import json_to_csv_converter
+import pandas as pd
+import os
+
+__dir__ = "data" # modify dataset directory if needed
+__location__ = os.path.realpath(
+    os.path.join(os.getcwd(), __dir__)
+)
+
+class CsvGenerator():
+    
+    def __init__(self, business_filename: str, review_filename: str):
+        self.business_filename = business_filename
+        self.review_filename = review_filename
+        self.business_ids = set()
+        
+    def read_csv(self):
+        business_df = pd.read_csv(os.path.join(__location__, self.business_filename))
+        review_df = pd.read_csv(os.path.join(__location__, self.review_filename))
+        print("read csv files successfully...")
+        
+        return business_df, review_df
+
+    def __clean_business_data(self, df: pd.DataFrame, columns: list[str]) -> pd.DataFrame:
+        df = df[columns]
+        df = df[df["categories"].str.contains("Cafe", na=False) | df['categories'].str.contains("Coffee", na=False)]
+        self.business_ids = set(df['business_id'])
+        print("cleaned business data")
+        
+        return df
+
+    def __clean_review_data(self, df: pd.DataFrame, columns: list) -> pd.DataFrame:
+        df = df[columns]
+        df = df[df['business_id'].isin(self.business_ids)]
+        print("cleaned review data")
+        
+        return df
+
+    def save_to_csv(self, df: pd.DataFrame, filename: str) -> None:
+        df.to_csv(os.path.join(__location__, filename))
+        print("saved updated csv")
+    
+    def run(self, business_columns: list[str], review_columns: list[str]) -> None:
+
+        business_df, review_df = self.read_csv()
+        business_df = self.__clean_business_data(business_df, business_columns)
+        review_df = self.__clean_review_data(review_df, review_columns)
+        self.save_to_csv(business_df, "business.csv")
+        self.save_to_csv(review_df, "review.csv")
+    
+
+        
+        
+if __name__ == "__main__":
+    """
+    hardcoded filenames, columns for now, need modification later
+    """
+    csv_generator = CsvGenerator("yelp_academic_dataset_business.csv", "yelp_academic_dataset_review.csv")
+    business_columns = ['is_open', 'postal_code', 'latitude',
+       'name', 'business_id', 'categories','address','city',
+       'longitude','hours', 'stars','state','review_count']
+    review_columns = ['business_id', 'text', 'stars', 'review_id', 'date']
+    csv_generator.run(business_columns, review_columns)

--- a/csv_generator/csv_generator.py
+++ b/csv_generator/csv_generator.py
@@ -22,7 +22,7 @@ class CsvGenerator():
         return business_df, review_df
 
     def __clean_business_data(self, df: pd.DataFrame, columns: list[str]) -> pd.DataFrame:
-        df = df[df['isopen'] == 1]
+        df = df[df['is_open'] == 1]
         df = df[columns]
         df = df[df["categories"].str.contains("Cafe", na=False) | df['categories'].str.contains("Coffee", na=False)]
         self.business_ids = set(df['business_id'])

--- a/csv_generator/json_to_csv_converter.py
+++ b/csv_generator/json_to_csv_converter.py
@@ -1,0 +1,129 @@
+"""Convert the Yelp Dataset Challenge dataset from json format to csv.
+
+For more information on the Yelp Dataset Challenge please visit http://yelp.com/dataset_challenge
+
+"""
+import argparse
+import collections
+import csv
+import simplejson as json
+
+
+def read_and_write_file(json_file_path, csv_file_path, column_names):
+    """Read in the json dataset file and write it out to a csv file, given the column names."""
+    with open(csv_file_path, 'w') as fout:
+        csv_file = csv.writer(fout)
+        csv_file.writerow(list(column_names))
+        with open(json_file_path, encoding="utf-8") as fin:
+            for line in fin:
+                line_contents = json.loads(line)
+                #print(column_names, line_contents)
+                csv_file.writerow(get_row(line_contents, column_names))
+
+def get_superset_of_column_names_from_file(json_file_path):
+    """Read in the json dataset file and return the superset of column names."""
+    column_names = set()
+    with open(json_file_path, encoding="utf-8") as fin:
+        for line in fin:
+            line_contents = json.loads(line)
+            column_names.update(
+                    set(get_column_names(line_contents).keys())
+                    )
+    return column_names
+
+def get_column_names(line_contents, parent_key=''):
+    """Return a list of flattened key names given a dict.
+
+    Example:
+
+        line_contents = {
+            'a': {
+                'b': 2,
+                'c': 3,
+                },
+        }
+
+        will return: ['a.b', 'a.c']
+
+    These will be the column names for the eventual csv file.
+
+    """
+    column_names = []
+    for k, v in line_contents.items():
+        column_name = "{0}.{1}".format(parent_key, k) if parent_key else k
+        if isinstance(v, collections.MutableMapping):
+            column_names.extend(
+                    get_column_names(v, column_name).items()
+                    )
+        else:
+            column_names.append((column_name, v))
+    return dict(column_names)
+
+def get_nested_value(d, key):
+    """Return a dictionary item given a dictionary `d` and a flattened key from `get_column_names`.
+    
+    Example:
+
+        d = {
+            'a': {
+                'b': 2,
+                'c': 3,
+                },
+        }
+        key = 'a.b'
+
+        will return: 2
+    
+    """
+    if '.' not in key:
+        if key not in d:
+            return None
+        return d[key]
+    base_key, sub_key = key.split('.', 1)
+    if base_key not in d:
+        return None
+    sub_dict = d[base_key]
+    if sub_dict is None:
+        return None
+    return get_nested_value(sub_dict, sub_key)
+
+def get_row(line_contents, column_names):
+    """Return a csv compatible row given column names and a dict."""
+    row = []
+    for column_name in column_names:
+        line_value = get_nested_value(
+                        line_contents,
+                        column_name,
+                        )
+        # print (line_value)
+        if isinstance(line_value, str):
+            row.append(line_value)
+        elif line_value is not None:
+            row.append(line_value)
+        else:
+            row.append('')
+    print(row)
+    return row
+
+if __name__ == '__main__':
+    """Convert a yelp dataset file from json to csv."""
+    
+    
+
+    parser = argparse.ArgumentParser(
+            description='Convert Yelp Dataset Challenge data from JSON format to CSV.',
+            )
+
+    parser.add_argument(
+            'json_file',
+            type=str,
+            help='The json file to convert.',
+            )
+
+    args = parser.parse_args()
+
+    json_file = args.json_file
+    csv_file = '{0}.csv'.format(json_file.split('.json')[0])
+
+    column_names = get_superset_of_column_names_from_file(json_file)
+    read_and_write_file(json_file, csv_file, column_names)


### PR DESCRIPTION
The datasets valid for the project are:
`yelp_academic_dataset_business.json` and `yelp_academic_dataset_review.json`.

Reading JSON files can be very slow, so they need to be converted to CSV format. The YELP sample example provides a script, `json_to_csv_converter.py`, to convert the JSON files into CSV. This step needs to be handled later.

Should we convert the original files to CSV first and have our program read from the CSV files, or should we start directly from the JSON files? The JSON files are very large and take a long time to process.

The CsvGenerator first reads the CSV files from the data/ directory, preprocesses the data, and then saves it as a new CSV file. You first need to download files from yelp and convert it to csv using the script (`json_to_csv_converter.py`).